### PR TITLE
ci: test the pull request's own code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
       - '.pre-commit-config.yaml'
       - 'pyproject.toml'
       - 'tests/**'
-  pull_request_target:
+  pull_request:
     branches:
       - master
     paths:

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
     - uses: actions/first-interaction@v3
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: |
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        issue_message: |
             Thanks for opening your first issue on **guard-agent**!
 
             To help us triage quickly, please make sure your report includes:
@@ -30,7 +30,7 @@ jobs:
             - **Security vulnerability?** Do **not** open a public issue — please follow [SECURITY.md](../blob/master/SECURITY.md) and use GitHub's private vulnerability reporting.
 
             Thanks again — a maintainer will be with you soon.
-        pr-message: |
+        pr_message: |
             Thanks for opening your first pull request on **guard-agent**!
 
             Quick checklist before review (most of these are enforced by CI, but worth a glance):


### PR DESCRIPTION
`ci.yml` triggered on `pull_request_target` with a bare `actions/checkout@v7` and no `ref:`, so **every run tested the base branch instead of the proposed change**. A pull request could show all-green while carrying a failing test, and the failure only surfaced once it reached master.

This was caught concretely in guard-core: a PR raising a timing assertion from `0.1` to `0.5` had its CI job run `assert elapsed < 0.1` — the base branch value — and fail.

`pull_request` checks out the head, so checks now reflect the code under review.

**Scope:** `ci.yml` only. `labeler.yml` and `greetings.yml` keep `pull_request_target` — they need write access to label and comment, and neither checks out or executes PR code, so they are safe and correct as-is. Adding `ref: github.event.pull_request.head.sha` to `pull_request_target` was rejected deliberately: it would run untrusted fork code with repository secrets and a write-scoped token.

**Known trade-off:** on pull requests from forks, secrets are not exposed, so the Slack notification steps and `IPINFO_TOKEN` will be empty. Pull requests from branches in this repository are unaffected.