### PR TITLE
Fix examples/basic_usage import path and async/typing bugs

### DIFF
--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -16,15 +16,14 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from fastapi import FastAPI, Request
-from guard import SecurityConfig, SecurityMiddleware
-from guard.decorators import SecurityDecorator
+from guard import SecurityConfig, SecurityDecorator, SecurityMiddleware
 
 from guard_agent import (
     AgentConfig,
+    GuardAgentHandler,
     SecurityEvent,
     SecurityMetric,
     get_current_timestamp,
-    guard_agent,
 )
 
 
@@ -50,7 +49,7 @@ async def basic_agent_usage() -> None:
     )
 
     # Get agent instance (singleton)
-    agent = guard_agent(config)
+    agent = GuardAgentHandler(config)
 
     try:
         # Start the agent (only needed for direct usage)
@@ -75,7 +74,7 @@ async def basic_agent_usage() -> None:
         # Example: Send custom metrics
         custom_metric = SecurityMetric(
             timestamp=get_current_timestamp(),
-            metric_type="custom_metric",
+            metric_type="request_count",
             value=42.0,
             endpoint="/api/custom",
             tags={"type": "business_metric", "category": "validation"},
@@ -89,7 +88,7 @@ async def basic_agent_usage() -> None:
         # Get agent status
         status = await agent.get_status()
         print(f"\nDirect agent status: {status.status}")
-        print(f"Events processed: {status.events_processed}")
+        print(f"Events processed: {status.events_sent}")
 
     finally:
         # Stop the agent (only needed for direct usage)
@@ -143,7 +142,7 @@ def create_fastapi_app_with_agent() -> FastAPI:
         buffer_size=50,
         flush_interval=30,
     )
-    agent = guard_agent(agent_config)
+    agent = GuardAgentHandler(agent_config)
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
@@ -192,13 +191,13 @@ def create_fastapi_app_with_agent() -> FastAPI:
             api_key="demo-api-key-12345",
             project_id="fastapi-demo",
         )
-        agent = guard_agent(agent_config)
+        agent = GuardAgentHandler(agent_config)
 
         # Send custom business logic event
         event = SecurityEvent(
             timestamp=get_current_timestamp(),
             event_type="custom_rule_triggered",
-            ip_address=request.client.host if request.client else None,
+            ip_address=request.client.host if request.client else "unknown",
             action_taken="logged",
             reason="Custom business logic event",
             endpoint="/custom-event",
@@ -217,7 +216,7 @@ def create_fastapi_app_with_agent() -> FastAPI:
             api_key="demo-api-key-12345",
             project_id="fastapi-demo",
         )
-        agent = guard_agent(agent_config)  # Get singleton instance
+        agent = GuardAgentHandler(agent_config)  # Get singleton instance
 
         try:
             status = await agent.get_status()


### PR DESCRIPTION
examples/basic_usage.py had pre-existing mypy errors and real bugs. CI (pre-commit `mypy guard_agent`) was green; this fixes the stricter local `make quality` gate.

Root-cause fixes, no `# type: ignore` / `# noqa` / `# nosec`:
- `from guard.decorators import SecurityDecorator` -> `from guard import SecurityConfig, SecurityDecorator, SecurityMiddleware`. guard.decorators does not exist in fastapi-guard 5.2.0 (SecurityDecorator is exported from the top-level guard package); the wrong path cascaded into untyped-decorator errors.
- `guard_agent(config)` -> `GuardAgentHandler(config)` at all 4 call sites. The factory returns GuardAgentHandler | SyncGuardAgentHandler based on a running loop; at import time (no loop) it returns the sync handler, so `await agent.start()` in the lifespan awaited None and raised TypeError. GuardAgentHandler is the async singleton the factory would return in async context.
- `metric_type="custom_metric"` -> `"request_count"` (SecurityMetric.metric_type is a Literal; "custom_metric" is invalid).
- `status.events_processed` -> `status.events_sent` (AgentStatus has no events_processed field).
- `ip_address=...else None` -> `else "unknown"` (SecurityEvent.ip_address is str, not str | None).

Gates: mypy . 39 files, ruff check + format, 406 passed / 2 skipped / 100% coverage.