### PR TITLE
Mute telemetry pydantic models when guard-core isn't imported

### DIFF
--- a/guard_agent/__init__.py
+++ b/guard_agent/__init__.py
@@ -7,6 +7,9 @@ monitoring, analytics, and dynamic rule management through a centralized
 management platform.
 """
 
+import logging
+from typing import Any, cast
+
 from guard_agent._version import __version__
 from guard_agent.buffer import EventBuffer
 from guard_agent.client import GuardAgentHandler, SyncGuardAgentHandler, guard_agent
@@ -67,3 +70,37 @@ __all__ = [
     "CircuitBreaker",
     "__version__",
 ]
+
+
+def _mute_pydantic_plugin_instrumentation() -> None:
+    """Opt guard-agent's hot-path telemetry models out of pydantic plugin
+    instrumentation (e.g. logfire.instrument_pydantic()).
+
+    SecurityEvent/SecurityMetric are validated per request and EventBatch
+    re-validates every buffered event on each flush, so an instrumented host
+    app would otherwise emit a span per security event. plugin_settings is
+    only read while building a model's validator, hence the forced rebuild.
+    Idempotent: guard-core applies the same mute to the same models; setting
+    the same plugin_settings and re-rebuilding is harmless.
+    """
+    try:
+        from guard_agent.models import EventBatch, SecurityEvent, SecurityMetric
+    except ImportError:
+        return
+    try:
+        for model in (SecurityEvent, SecurityMetric, EventBatch):
+            plugin_settings = cast(
+                "dict[str, Any]",
+                model.model_config.setdefault("plugin_settings", {}),
+            )
+            plugin_settings["logfire"] = {"record": "off"}
+            model.model_rebuild(force=True)
+    except Exception:
+        logging.getLogger("guard_agent").warning(
+            "Could not opt guard-agent telemetry models out of pydantic "
+            "plugin instrumentation",
+            exc_info=True,
+        )
+
+
+_mute_pydantic_plugin_instrumentation()

--- a/tests/test_init_instrumentation.py
+++ b/tests/test_init_instrumentation.py
@@ -1,0 +1,57 @@
+import logging
+import subprocess
+import sys
+
+import pytest
+
+import guard_agent
+from guard_agent.models import EventBatch, SecurityEvent, SecurityMetric
+
+_STANALONE_CHECK = (
+    "import sys; "
+    "assert 'guard_core' not in sys.modules, 'guard-core leaked into standalone'; "
+    "import guard_agent; "
+    "from guard_agent.models import SecurityEvent, SecurityMetric, EventBatch; "
+    "models = [SecurityEvent, SecurityMetric, EventBatch]; "
+    "muted = all(m.model_config.get('plugin_settings', {}).get('logfire') == "
+    "{'record': 'off'} for m in models); "
+    "assert 'guard_core' not in sys.modules, 'guard-core imported by guard_agent'; "
+    "assert muted, 'telemetry models not muted without guard-core'; "
+    "print('standalone-ok')"
+)
+
+
+def test_telemetry_models_muted_after_import() -> None:
+    expected = {"record": "off"}
+    for model in (SecurityEvent, SecurityMetric, EventBatch):
+        plugin_settings = model.model_config.get("plugin_settings", {})
+        assert plugin_settings.get("logfire") == expected, (
+            f"{model.__name__} logfire plugin_settings not muted"
+        )
+
+
+def test_mute_survives_rebuild_failure(
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def boom(*args, **kwargs) -> None:
+        raise RuntimeError("rebuild failed")
+
+    monkeypatch.setattr(SecurityEvent, "model_rebuild", boom)
+
+    with caplog.at_level(logging.WARNING, logger="guard_agent"):
+        guard_agent._mute_pydantic_plugin_instrumentation()
+
+    assert "Could not opt guard-agent telemetry models" in caplog.text
+
+
+def test_mute_applied_standalone_without_guard_core() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _STANALONE_CHECK],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"standalone mute check failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "standalone-ok" in result.stdout


### PR DESCRIPTION
guard-core v3.8.1 mutes the guard-agent telemetry models (SecurityEvent / SecurityMetric / EventBatch) at import via pydantic `plugin_settings` logfire record off + `model_rebuild`, so a consumer's bare `instrument_pydantic()` does not emit guard-event validation spans.

Edge case: a host using guard-agent WITHOUT importing guard-core has unmuted models (the mute fires only on guard_core import). This adds a parallel, idempotent `_mute_pydantic_plugin_instrumentation()` to `guard_agent/__init__.py` mirroring guard_core's, applied at import. No logfire import; no-op on ImportError; swallows failures with a WARNING. Closes the standalone-guard-agent edge case.

Gates: ruff + mypy clean; full suite green.