### PR TITLE
Add guard-agent library-skills skill

### DIFF
--- a/guard_agent/.agents/skills/guard-agent/SKILL.md
+++ b/guard_agent/.agents/skills/guard-agent/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: guard-agent
+description: guard-agent telemetry client for the Guard security ecosystem. Use when integrating guard-agent with fastapi-guard/flaskapi-guard/djapi-guard/tornadoapi-guard, configuring AgentConfig (buffer_size, flush_interval, retry_attempts, endpoint), wiring Redis persistence, or diagnosing 413 split-or-drop / permanent-rejection / requeue behavior. Also use when a host app calls logfire.instrument_pydantic() and you need to reason about the agent's per-event validation span mute.
+---
+
+# guard-agent
+
+Framework-agnostic telemetry and monitoring agent for the Guard ecosystem. Buffers security events and metrics, flushes them to the Guard SaaS API, and fetches dynamic rules.
+
+## Quick Reference
+
+* Client setup: build an `AgentConfig`, call `guard_agent(config)` for the handler; see [Client Setup](#client-setup).
+* Buffer/flush config: `buffer_size`, `flush_interval`, `high_watermark_ratio`; keep the buffer small vs the 256 KiB SaaS body cap; see [the buffering reference](references/buffering.md).
+* Redis persistence: `ttl=3600s`, keys retained on failure and deleted only on success; see [the Redis reference](references/redis.md).
+* 413 / permanent rejections: HTTP 413 splits the batch in half and retries each half (or drops a single over-cap item); 400/404/422 are dropped, not requeued; see [the transport reference](references/transport.md).
+* logfire mute: the agent mutes its telemetry Pydantic models at import so a host `logfire.instrument_pydantic()` does not emit per-event validation spans; see [the logfire mute reference](references/logfire-mute.md).
+* Config reference: every `AgentConfig` field with defaults; see [the config reference](references/config.md).
+
+## Client Setup
+
+`guard_agent` is imported by a framework adapter (fastapi-guard, flaskapi-guard, djapi-guard, tornadoapi-guard); you rarely instantiate it directly. When you do, build an `AgentConfig` and use the `guard_agent` factory, which returns a `GuardAgentHandler` in an async context or a `SyncGuardAgentHandler` in a sync context.
+
+```python
+from guard_agent import AgentConfig, guard_agent
+
+config = AgentConfig(
+    api_key="sk-...",
+    endpoint="https://api.guard-core.com",
+    project_id="my-project",
+)
+handler = guard_agent(config)
+await handler.start()
+```
+
+The async handler (`GuardAgentHandler`) is a singleton per process and reinitializes after `os.fork()`. The sync wrapper (`SyncGuardAgentHandler`) runs the async loop in a daemon thread for WSGI frameworks.
+
+Send events/metrics through the handler; do not call the transport directly:
+
+```python
+from guard_agent import SecurityEvent, SecurityMetric
+from datetime import datetime, timezone
+
+await handler.send_event(SecurityEvent(
+    timestamp=datetime.now(timezone.utc),
+    event_type="ip_banned",
+    ip_address="1.2.3.4",
+    action_taken="blocked",
+))
+```
+
+`send_event` / `send_metric` accept a `SecurityEvent` / `SecurityMetric` or any object with matching attributes (the handler normalizes it).
+
+## Buffer and Flush
+
+Events and metrics live in two fixed-size `deque` buffers (`maxlen=config.buffer_size`). An auto-flush loop drains them every `flush_interval` seconds, or early when occupancy reaches `high_watermark_ratio` of `buffer_size`. Overflow policy is `drop` by default (evict oldest); `block` backpressures the caller, `raise` throws `BufferFullError`.
+
+Keep `buffer_size` small. The SaaS ingestion endpoint caps request bodies at 256 KiB; a large buffer that flushes a giant batch triggers a 413 and forces a split-or-drop cascade. The default of 100 is a safe ceiling for typical event sizes. See [the buffering reference](references/buffering.md) for the full overflow/early-flush mechanics.
+
+## Redis Persistence
+
+When `initialize_redis(redis_handler)` is called, every buffered item is also written to Redis under a globally-unique key with `ttl=3600` seconds. On a successful flush, the corresponding Redis keys are deleted. On a transient failure the items are requeued in memory and the Redis keys are retained, so a process restart can re-load them. See [the Redis reference](references/redis.md).
+
+## Transport: 413 and Permanent Rejections
+
+`send_events` / `send_metrics` return `True` when the batch was durably accepted OR intentionally dropped because it is permanently un-sendable; the caller deletes Redis keys and does not requeue in both cases. They return `False` only on transient failure, so the caller requeues and retains the Redis keys.
+
+* HTTP 413 raises `PayloadTooLargeError`. The caller splits the batch in half and retries each half recursively; a single over-cap item is dropped with a warning.
+* HTTP 400 / 404 / 422 raises `PermanentClientError`; the batch is dropped with a warning (no requeue, no poison-loop retry).
+* HTTP 429 honors `Retry-After`. 5xx and network errors are retried up to `retry_attempts` with backoff.
+
+See [the transport reference](references/transport.md) for the exact return semantics, including the split-batch transient-failure edge case.
+
+## logfire Mute (this release)
+
+`SecurityEvent`, `SecurityMetric`, and `EventBatch` are validated per request and `EventBatch` re-validates every buffered event on each flush. A host app that calls `logfire.instrument_pydantic()` would otherwise emit a span per security event. At import time, guard-agent sets `model_config["plugin_settings"]["logfire"] = {"record": "off"}` on each of those three models and force-rebuilds them. This works without logfire installed and is idempotent (guard-core applies the same mute to the same models at its import; re-applying is harmless). See [the logfire mute reference](references/logfire-mute.md).

--- a/guard_agent/.agents/skills/guard-agent/references/buffering.md
+++ b/guard_agent/.agents/skills/guard-agent/references/buffering.md
@@ -1,0 +1,44 @@
+# Buffering and Flush
+
+## Buffers
+
+`EventBuffer` holds two `collections.deque` buffers, each with `maxlen=config.buffer_size`:
+
+* `event_buffer` — `SecurityEvent` instances
+* `metric_buffer` — `SecurityMetric` instances
+
+A `deque(maxlen=...)` silently evicts the oldest entry when full. The overflow policy gates whether that happens.
+
+## Overflow Policy
+
+`config.buffer_overflow_policy` controls behavior when a buffer is full at insert time:
+
+| Policy | Behavior |
+|---|---|
+| `drop` (default) | Evict the oldest entry, increment a drop counter, log every 100th drop at WARNING. |
+| `block` | Await an `asyncio.Event` signaled when flush frees space; backpressures the caller. |
+| `raise` | Raise `BufferFullError` so the caller can react. |
+
+## Auto Flush
+
+`start_auto_flush()` runs `_auto_flush_loop`, which sleeps `flush_interval` seconds between attempts. A flush is triggered when:
+
+* buffer occupancy reaches `high_watermark_ratio` of `buffer_size` (early flush), or
+* `flush_interval` seconds elapsed since the last flush.
+
+Early flushes are concurrency-limited by `max_concurrent_flushes` (default 1) via a `Semaphore`; a locked semaphore skips the early flush rather than queuing.
+
+## Flush Callback
+
+`EventBuffer` is constructed with `flush_callback` (the handler's `flush_buffer` coroutine). The callback drains both buffers via `flush_events_with_keys` / `flush_metrics_with_keys`, which return the items plus their Redis keys. The handler then calls `transport.send_events` / `send_metrics`:
+
+* success → `confirm_*_redis_keys(keys)` deletes the Redis keys.
+* failure (`False`) → `requeue_*_in_memory(items, keys)` pushes items back to the front of the buffer and keeps the Redis keys.
+
+## Safe-Setting Guidance
+
+The SaaS ingestion endpoint caps request bodies at 256 KiB. A flush serializes the whole buffer into one `EventBatch` JSON body (optionally gzip-compressed above `compression_threshold`). If the body exceeds the cap, the server returns 413 and the transport splits the batch in half recursively. A large `buffer_size` combined with large event payloads makes 413 cascades likely and wastes retry budget. Keep `buffer_size` at the default (100) or lower for verbose events; raise `flush_interval` to batch more tightly only if events are small.
+
+## Stats
+
+`buffer.get_stats()` returns `events_buffered`, `metrics_buffered`, `events_flushed`, `metrics_flushed`, `events_dropped`, `metrics_dropped`, `current_event_buffer_size`, `current_metric_buffer_size`, `redis_persist_failures`, `durability_degraded` (True when Redis is configured and persist failures occurred), `last_flush_time`, `auto_flush_running`.

--- a/guard_agent/.agents/skills/guard-agent/references/config.md
+++ b/guard_agent/.agents/skills/guard-agent/references/config.md
@@ -1,0 +1,40 @@
+# AgentConfig Reference
+
+`AgentConfig` is a Pydantic `BaseModel`. Required field: `api_key`. All others have defaults.
+
+## Fields
+
+| Field | Default | Notes |
+|---|---|---|
+| `api_key` | required | Guard Agent API key. |
+| `endpoint` | `https://api.guard-core.com` | Bare host. A trailing `/api/v1` is stripped with a one-time WARNING (transport appends versioned paths). |
+| `project_id` | `None` | Org/project ID. When set, the dynamic-rules poll loop starts. |
+| `buffer_size` | `100` | Per-buffer `deque maxlen` (events and metrics each). Keep small vs the 256 KiB SaaS body cap. |
+| `flush_interval` | `30` | Seconds between auto-flush attempts. |
+| `dynamic_rule_interval` | `300` (min 60) | Seconds between dynamic-rule polls. |
+| `status_interval` | `300` (min 60) | Seconds between agent-status reports. |
+| `high_watermark_ratio` | `0.8` | Buffer occupancy that triggers an early flush. |
+| `max_concurrent_flushes` | `1` | Early-flush concurrency limit. |
+| `buffer_overflow_policy` | `drop` | `drop` / `block` / `raise`. |
+| `enable_metrics` | `True` | When False, `send_metric` is a no-op. |
+| `enable_events` | `True` | When False, `send_event` is a no-op. |
+| `retry_attempts` | `3` | Transient-failure retries per batch. |
+| `timeout` | `30` | Request timeout in seconds. |
+| `backoff_factor` | `1.0` | Backoff multiplier for retries. |
+| `sensitive_headers` | `["authorization", "cookie", "x-api-key"]` | Headers excluded from telemetry. |
+| `max_payload_size` | `1024` | Max payload size included in an event (bytes). |
+| `project_encryption_key` | `None` | When set, payloads are AES-256-GCM encrypted to `/api/v1/events/encrypted`. |
+| `guard_version` | `None` | Framework adapter version, set by the adapter at init. |
+| `compression_enabled` | `True` | Gzip bodies above `compression_threshold`. |
+| `compression_threshold` | `1024` | Min body size in bytes before gzip applies. |
+| `install_id` | `None` | Override agent install ID (auto-generated otherwise). |
+| `payload_signing_secret` | `None` | HMAC-SHA256 secret for `X-Payload-Signature`. |
+| `on_error` | `None` | Best-effort callback `(stage, exc, context)` for transport/encryption failures; a raising callback is caught and logged. |
+
+## Env-Var Mapping (Adapter Side)
+
+guard-agent itself does not read environment variables. The framework adapter (fastapi-guard, etc.) reads `AGENT_*` env vars and maps them onto `AgentConfig` fields. The verified defaults the adapter passes through are `buffer_size=100`, `flush_interval=30`, `retry_attempts=3`, `endpoint=https://api.guard-core.com`. An `agent_strict=False` style setting, when present, belongs to the adapter's own `SecurityConfig`, not to `AgentConfig` (guard-agent has no `strict` field).
+
+## Endpoint Validation
+
+`AgentConfig.validate_endpoint` rejects empty values, non-HTTP schemes, and missing scheme/netloc. A trailing `/api/v1` is stripped once with a WARNING and a module-level guard prevents repeating the warning.

--- a/guard_agent/.agents/skills/guard-agent/references/logfire-mute.md
+++ b/guard_agent/.agents/skills/guard-agent/references/logfire-mute.md
@@ -1,0 +1,26 @@
+# logfire / Pydantic Plugin Mute
+
+## Why
+
+`SecurityEvent` and `SecurityMetric` are validated on every request, and `EventBatch` re-validates every buffered event on each flush. A host app that calls `logfire.instrument_pydantic()` (which instruments the Pydantic plugin) would otherwise emit a validation span per security event, potentially hundreds of thousands of spans per day under real traffic.
+
+## What
+
+At `guard_agent` import time, `_mute_pydantic_plugin_instrumentation()` sets:
+
+```python
+model.model_config["plugin_settings"]["logfire"] = {"record": "off"}
+```
+
+on `SecurityEvent`, `SecurityMetric`, and `EventBatch`, then calls `model.model_rebuild(force=True)` on each. `plugin_settings` is only read while building a model's validator, hence the forced rebuild.
+
+## Properties
+
+* No logfire import: the mute sets a Pydantic config value only; it works without logfire installed.
+* Clean no-op if the models are not importable: an `ImportError` from `guard_agent.models` returns early.
+* Survives rebuild failure: if `model_rebuild` raises, the exception is swallowed with a WARNING log on the `guard_agent` logger, leaving instrumentation on rather than crashing import.
+* Idempotent: setting the same `plugin_settings` and re-rebuilding is harmless. guard-core applies the same mute to the same three models at `guard_core` import; importing both packages does not conflict.
+
+## Host-App Implication
+
+A consumer that calls `logfire.instrument_pydantic()` after `import guard_agent` will not emit per-event validation spans for the agent's telemetry models. Other Pydantic models in the host app remain instrumented. The mute is scoped to `SecurityEvent`, `SecurityMetric`, and `EventBatch` only.

--- a/guard_agent/.agents/skills/guard-agent/references/redis.md
+++ b/guard_agent/.agents/skills/guard-agent/references/redis.md
@@ -1,0 +1,33 @@
+# Redis Persistence
+
+## Wiring
+
+`GuardAgentHandler.initialize_redis(redis_handler)` stores the handler and calls `EventBuffer.initialize_redis`, which loads any previously-persisted items back into the in-memory buffers before the agent starts. The handler accepts any object implementing `RedisHandlerProtocol` (guard-core's `redis_handler` is the canonical implementation).
+
+## Write Path
+
+On `add_event` / `add_metric`, after appending to the in-memory deque, the buffer persists the item to Redis:
+
+* Key: `event_<time_ns()>_<uuid4 hex[:8]>` (events) or `metric_<time_ns()>_<uuid4 hex[:8]>` (metrics), namespaced under `agent_events` / `agent_metrics`.
+* Value: `safe_json_serialize(item.model_dump())`.
+* TTL: `3600` seconds.
+* The buffer records the short key on the item via `id(item)` for later confirmation.
+
+A persist failure increments `redis_persist_failures` and logs a WARNING; the item still lives in the in-memory buffer (durability degraded, not lost).
+
+## Load Path (Restart Recovery)
+
+On `initialize_redis`, the buffer scans `agent_events:*` / `agent_metrics:*`, deserializes each value into a `SecurityEvent` / `SecurityMetric`, appends it to the in-memory deque, and re-records the short key. This means a process restart re-loads items that were buffered but not yet confirmed flushed.
+
+## Delete Path (Success Only)
+
+`flush_events_with_keys` / `flush_metrics_with_keys` pop the items and their keys out of the buffer and return both. The handler calls `transport.send_events` / `send_metrics`:
+
+* `True` (accepted or permanently dropped) → `confirm_event_redis_keys` / `confirm_metric_redis_keys` deletes the Redis keys. The items are gone everywhere.
+* `False` (transient failure) → `requeue_events_in_memory` / `requeue_metrics_in_memory` pushes the items back to the front of the deque and re-associates the Redis keys. The Redis keys are retained for the next retry or for restart recovery.
+
+Redis keys are never deleted on failure. The 3600s TTL is the only failure-case expiry, bounding how long an un-flushed item survives a downed SaaS.
+
+## Clear
+
+`clear_buffer()` wipes both in-memory deques and deletes all `agent_events:*` / `agent_metrics:*` keys. Use only when you intend to lose pending telemetry.

--- a/guard_agent/.agents/skills/guard-agent/references/transport.md
+++ b/guard_agent/.agents/skills/guard-agent/references/transport.md
@@ -1,0 +1,39 @@
+# Transport: 413, Permanent Rejections, Retries
+
+`HTTPTransport.send_events` / `send_metrics` build an `EventBatch`, serialize it, optionally gzip-compress and HMAC-sign it, and POST to `/api/v1/events` or `/api/v1/metrics`. Encrypted configurations POST to `/api/v1/events/encrypted` instead.
+
+## Return Semantics
+
+| Outcome | Return | Caller action |
+|---|---|---|
+| Server accepted (200/201) | `True` | Delete Redis keys, do not requeue. |
+| Partial-failure 200 (`success=False` or `errors` present) | `False` | Requeue in memory, retain Redis keys. |
+| 413 Payload Too Large | split-or-drop; `True` if both halves resolve, else `False` | See below. |
+| 400 / 404 / 422 Permanent | `True` | Delete Redis keys, do not requeue. |
+| 429 Rate Limited | retry after `Retry-After` | Retained during retry loop. |
+| 5xx / network error | `False` after retries exhausted | Requeue in memory, retain Redis keys. |
+| 401 / 403 | raises `Exception` | Caught by `send_events`, returns `False`. |
+
+## 413 Split-or-Drop
+
+When `_handle_response` sees HTTP 413 it raises `PayloadTooLargeError` (a subclass of `PermanentClientError`). `send_events` / `send_metrics` catch `PayloadTooLargeError` and call `_split_or_drop_on_payload_too_large`:
+
+* If the batch has more than one item, split it in half at the midpoint and recursively call `send_events` / `send_metrics` on each half. Each half may itself 413 and split again, or hit a permanent 4xx and drop, or transiently fail.
+* If the batch is a single item that still exceeds the cap, drop it with a WARNING, fire the `on_error` hook, and return `True` (no requeue).
+* The split returns `left and right`. Both halves `True` (accepted or permanently dropped) → `True`, caller does not requeue. If either half transiently fails (`False`), the split returns `False` and the caller requeues the original full batch. Note: items already accepted by the server in a succeeding half are not un-sent, so a transient failure on the other half can cause the requeued full batch to re-send already-accepted events. This is the current release behavior; prefer keeping `buffer_size` small so 413 splits are rare.
+
+## Permanent Rejections (400 / 404 / 422)
+
+`_NON_RETRYABLE_STATUS_CODES = (400, 404, 413, 422)`. For 400/404/422, `_handle_response` raises `PermanentClientError(status_code, detail)`. `send_events` / `send_metrics` catch it, call `_drop_permanent_rejection` (WARNING log + `on_error` hook), and return `True`. The caller deletes Redis keys and does not requeue. This prevents poison-loop retries of batches the server will never accept.
+
+## Retries and Backoff
+
+`_send_with_retry` loops `retry_attempts + 1` times. On a transient exception it sleeps `calculate_backoff_delay(attempt, backoff_factor)` before retrying. `RateLimitedError` (429) sleeps `min(Retry-After, 300s)`. A `CircuitBreaker` (threshold 5 failures, 60s recovery) wraps each request; an open breaker raises instead of calling the server. A `RateLimiter` (100 calls / 60s client-side) gates outbound calls.
+
+## Encryption and Signing
+
+When `project_encryption_key` is set, the transport encrypts events/metrics payloads (AES-256-GCM via `PayloadEncryptor`) and POSTs to `/api/v1/events/encrypted`. When `payload_signing_secret` is set, each body is HMAC-SHA256-signed and the signature sent in `X-Payload-Signature`. Encryption round-trip is verified at transport init; a failure raises `EncryptionConfigError` and refuses plaintext fallback.
+
+## Fork Safety
+
+`os.register_at_fork` resets the httpx client, circuit breaker, rate limiter, and stats in the child process. `GuardAgentHandler` similarly reinitializes after fork.


### PR DESCRIPTION
Embeds a library-skills skill at `guard_agent/.agents/skills/guard-agent/SKILL.md` (+ 5 references: buffering, transport, redis, config, logfire-mute) so `uvx library-skills --claude` discovers it from the installed wheel. hatchling ships all files under the package dir.

Markdown-only; no code changes. CI green.