### PR TITLE
Route docs readers to the platform (docs 747 → landing 133)

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -92,3 +92,12 @@
 .md-header__button.md-logo svg {
     height: 1.8rem;
 }
+.gc-announce {
+  text-align: center;
+}
+
+.gc-announce a {
+  color: inherit;
+  font-weight: 700;
+  text-decoration: underline;
+}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block announce %}
+  <div class="gc-announce">
+    Running Guard in production?
+    <a href="https://guard-core.com/?utm_source=docs&amp;utm_medium=guard-agent&amp;utm_campaign=docs_announce">The hosted platform</a>
+    adds live dashboards, alerting and dynamic rules you can push without a redeploy.
+    <a href="https://playground.guard-core.com/?utm_source=docs&amp;utm_medium=guard-agent&amp;utm_campaign=docs_announce_playground">Try the playground</a>
+    first, no account needed.
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Why

The docs are where the audience is, and nothing on a docs page routes anywhere.

Measured funnel: docs 747 → landing 133 → app 119 → signups 22. Landing to app is 89% and app to signup is 18%, so everything downstream of the landing page already converts. The only broken step is docs to landing, where 82% of readers never cross. The platform is currently mentioned only in the README, which readers see once, and in incidental prose on about ten scattered pages.

## What this does

Adds a sitewide announcement bar via a new `docs/overrides/main.html`, which MkDocs Material renders on every page. `custom_dir: docs/overrides` was already configured and no `main.html` existed, so nothing is overridden or displaced.

It points at the landing page, deliberately, rather than at signup or the playground. The landing page feeds a funnel whose downstream conversion is already proven, and keeping one entry point means next month's numbers answer "did the bridge work" instead of "what changed". The playground is offered as a secondary link, tagged separately, so we learn whether technical readers prefer it without betting the primary route on a guess.

## Attribution

Every link carries `utm_source=docs`, `utm_medium=<repo>` and `utm_campaign=docs_announce` (or `docs_announce_playground`). This is the part that compounds: docs-to-landing attribution does not exist today, which is exactly why this leak stayed invisible until the funnel was pulled by hand. After this, the next read shows which repo's docs convert and whether the playground outperforms the landing page.

## Scope

Documentation only. No package code, no dependencies, no build or packaging changes. The same change lands in guard-core, fastapi-guard, guard-agent and guard-core-mcp so a reader converts from whichever docs site they arrived on.

Deliberately kept off the in-flight release branches so it can be reviewed, reworded or reverted on its own.

## Verification

`mkdocs build --strict` passes in all four repos, and the bar is confirmed present in the built HTML rather than only in the template.

## Copy

The wording is a starting point, not a decision. It lives in one file per repo and is a one-line edit.
